### PR TITLE
Add watch option

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -11,7 +11,10 @@ module.exports = ({ configPath }) => {
   if (fs.existsSync(ngTwFile)) {
     const config = require(ngTwFile)
 
-    const tailwind = chokidar.watch([config.configJS, config.sourceCSS])
+    let tailwind = chokidar.watch([config.configJS, config.sourceCSS])
+    if (config.watch) {
+      tailwind = tailwind.concat(config.watch)
+    }
 
     tailwind.on('change', (event, path) => {
       console.log('Reprocessing changes to Tailwind files')


### PR DESCRIPTION
Added "watch" option in ng-tailwind.js 
The option is added to the default list of files to watch (configJS and sourceCSS).
The option is a chockidar parameter to chockadir.watch([....]) call